### PR TITLE
Use right filter titles and proper parameters

### DIFF
--- a/core/Carbon_Breadcrumb_Item_Post.php
+++ b/core/Carbon_Breadcrumb_Item_Post.php
@@ -27,7 +27,7 @@ class Carbon_Breadcrumb_Item_Post extends Carbon_Breadcrumb_Item_DB_Object {
 	 */
 	public function setup_title() {
 		$title = get_post_field( 'post_title', $this->get_id() );
-		$title = apply_filters( 'the_title', $title );
+		$title = apply_filters( 'the_title', $title, $this->get_id() );
 		$this->set_title( $title );
 	}
 

--- a/core/Carbon_Breadcrumb_Item_Term.php
+++ b/core/Carbon_Breadcrumb_Item_Term.php
@@ -43,7 +43,14 @@ class Carbon_Breadcrumb_Item_Term extends Carbon_Breadcrumb_Item_DB_Object {
 	 * @access public
 	 */
 	public function setup_title() {
-		$title = apply_filters( 'the_title', $this->term_object->name );
+		$filter_name = 'single_term_title';
+		if ( $this->term_object->taxonomy === 'category' ) {
+			$filter_name = 'single_cat_title';
+		} elseif ( $this->term_object->taxonomy === 'post_tag' ) {
+			$filter_name = 'single_tag_title';
+		}
+
+		$title = apply_filters( $filter_name, $this->term_object->name );
 		$this->set_title( $title );
 	}
 

--- a/core/Carbon_Breadcrumb_Item_User.php
+++ b/core/Carbon_Breadcrumb_Item_User.php
@@ -26,7 +26,7 @@ class Carbon_Breadcrumb_Item_User extends Carbon_Breadcrumb_Item_DB_Object {
 	 * @access public
 	 */
 	public function setup_title() {
-		$title = apply_filters( 'the_title', get_the_author_meta( 'display_name', $this->get_id() ) );
+		$title = apply_filters( 'the_author', get_the_author_meta( 'display_name', $this->get_id() ) );
 		$this->set_title( $title );
 	}
 


### PR DESCRIPTION
This PR updates the breadcrumbs to use the right filter when displaying the title of:
* User - use the `the_author` filter.
* Term - use:
  * `single_cat_title` for categories
  * `single_tag_title` for tags
  * `single_term_title` for others

Additionally, it adds the second ID parameter to the `the_title` filter, so it no longer errors out under some circumstances.

Fixes #42.